### PR TITLE
fix(slack-bot): 処理タイムアウトを5分→20分に延長

### DIFF
--- a/slack-bot/index.js
+++ b/slack-bot/index.js
@@ -383,7 +383,7 @@ async function callClaude(prompt, workDir = BASE_DIR) {
         '--add-dir', PROJECTS_ROOT,  // 全プロジェクト横断アクセス
       ], {
         cwd: workDir,
-        timeout: 300000,
+        timeout: 20 * 60 * 1000, // 20分
       });
     } catch (err) {
       throw err; // ETIMEDOUT 등
@@ -517,7 +517,7 @@ MANDATORY RULE — Task Number: If the user's message contains a 14-digit task n
   } catch (err) {
     const isTimeout = err.code === 'ETIMEDOUT' || (err.message && err.message.includes('ETIMEDOUT'));
     const msg2 = isTimeout
-      ? '⏱️ 処理がタイムアウトしました（5分超過）。もう少し短い要求に分けて送ってください。'
+      ? '⏱️ 処理がタイムアウトしました（20分超過）。もう少し短い要求に分けて送ってください。'
       : `回答エラー: ${err.message}`;
     await postMessage(channelId, msg2, replyTs);
   }

--- a/slack-bot/task-manager.js
+++ b/slack-bot/task-manager.js
@@ -102,7 +102,7 @@ function runClaude(args, cwd = BASE_DIR) {
     cwd,
     encoding: 'utf8',
     maxBuffer: 10 * 1024 * 1024,
-    timeout: 300000,
+    timeout: 20 * 60 * 1000, // 20分
     windowsHide: true,
   });
   if (result.error) throw result.error;


### PR DESCRIPTION
## 概要
Slack ボットの処理タイムアウトを 5分 → 20分 に延長。

ユーザー要望: タイムアウトメッセージが「5分超過」で早すぎるため 20分にしてほしい (task 20260703194500)。

## 変更点
- `slack-bot/index.js`
  - `callClaude`(Q&A経路) の spawn `timeout`: `300000` → `20 * 60 * 1000`
  - タイムアウト通知メッセージ: 「5分超過」→「20分超過」
- `slack-bot/task-manager.js`
  - `runClaude`(タスク実行経路) の spawn `timeout`: `300000` → `20 * 60 * 1000`

`node --check` 構文検証済み。同一変更を Lowyworkenv レポにも反映済み（コード2重管理のため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)