### PR TITLE
docs(readme): 설치 가이드를 slack-bot 기동 중심으로 재작성 (KO/JA/EN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,29 +39,144 @@
 
 ---
 
-## 💻 내 PC에 FDE Agent 설치하기
+## 💻 내 PC에 FDE Agent 설치하기 — Slack 봇부터 띄우기
 
-여러분의 프로젝트 폴더로 이동한 뒤 아래 명령으로 에이전트 파일을 이식하면(**`.git` 폴더 제외**), 즉시 FDE Agent가 활성화됩니다.
+`giip-fde-agent`는 **public 레포지토리**입니다. 따라서 이 레포 폴더 안에서 바로 작업하지 말고,
+**레포를 받아 → 여러분이 작업 메인으로 쓸 폴더로 필요한 파일을 복사한 뒤 → 그 폴더를 워크스페이스로 삼아 Slack 봇을 띄우는** 것이
+가장 빠르고 안전한 시작입니다. 이렇게 하면 업데이트를 받을 때 레포를 다시 pull 해도 여러분의 작업물과 섞이지 않습니다.
 
-### Windows (PowerShell)
+아래 순서대로 하면 **Slack에서 `@봇 <요청>`으로 FDE Agent에게 일을 시킬 수 있는 상태**까지 도달합니다.
+
+### 사전 준비 (Prerequisites)
+
+- **Node.js 18+** (`node -v`)
+- **Claude CLI** 설치 및 로그인 — 봇은 Anthropic API Key 없이 `claude -p` CLI를 그대로 구동합니다.
+  `claude --version`이 동작하고, 한 번 로그인(`claude` 실행 후 인증)돼 있어야 합니다. → [Claude Code](https://claude.ai/code)
+- **Slack 워크스페이스 관리자 권한** (앱을 설치할 수 있어야 함)
+
+---
+
+### 1단계. 레포 받기 & 작업 메인 폴더로 복사
+
+먼저 레포를 클론하고, **여러분이 작업 메인으로 쓸 폴더**(예: `C:\work\my-project`)를 만든 뒤 그 폴더로 에이전트 파일을 복사합니다(**`.git` 폴더 제외**).
+
+#### Windows (PowerShell)
 ```powershell
-# 필수 파일 복사 (giip-fde-agent 폴더 안에서 실행 또는 상대 경로 지정)
-Copy-Item -Path ".agent", "GEMINI.md", ".cursorrules", "COPILOT_INSTRUCTIONS.md" -Destination "내_프로젝트_경로" -Recurse -Force
+# 1) 레포 클론 (임의 위치)
+git clone https://github.com/LowyShin/giip-fde-agent.git
+
+# 2) 작업 메인 폴더 생성 (경로는 원하는 대로)
+New-Item -ItemType Directory -Force "C:\work\my-project"
+
+# 3) 에이전트 + slack-bot 파일을 작업 폴더로 복사
+cd giip-fde-agent
+Copy-Item -Path ".agent", "GEMINI.md", ".cursorrules", "COPILOT_INSTRUCTIONS.md", "slack-bot" -Destination "C:\work\my-project" -Recurse -Force
 ```
 
-### Mac/Linux
+#### Mac/Linux
 ```bash
-# 필수 파일 복사 (rsync 사용 권장)
-rsync -av --exclude='.git' .agent GEMINI.md .cursorrules COPILOT_INSTRUCTIONS.md 내_프로젝트_경로/
+# 1) 레포 클론
+git clone https://github.com/LowyShin/giip-fde-agent.git
+
+# 2) 작업 메인 폴더 생성
+mkdir -p ~/work/my-project
+
+# 3) 에이전트 + slack-bot 파일을 작업 폴더로 복사 (.git 제외)
+cd giip-fde-agent
+rsync -av --exclude='.git' .agent GEMINI.md .cursorrules COPILOT_INSTRUCTIONS.md slack-bot ~/work/my-project/
 ```
+
+> 이후 모든 작업은 **복사한 작업 폴더**(`C:\work\my-project`)에서 진행합니다. 원본 `giip-fde-agent` 폴더는 업데이트 수신용으로만 두세요.
+
+---
+
+### 2단계. Slack 앱 만들기 (Socket Mode)
+
+봇은 공개 URL이 필요 없는 **Socket Mode**로 동작합니다. [api.slack.com/apps](https://api.slack.com/apps)에서 앱을 만들고 아래 두 토큰을 발급받으세요.
+
+1. **Create New App → From scratch** 로 앱 생성
+2. **Socket Mode** 활성화 → App-Level Token 생성(스코프 `connections:write`) → `xapp-...` 복사
+3. **OAuth & Permissions → Bot Token Scopes**: `chat:write`, `app_mentions:read`, `channels:history`, `channels:read`, `groups:history`, `im:history`, `im:read`, `im:write`, `users:read`
+4. **Event Subscriptions** 활성화 → Subscribe to bot events: `app_mention`, `message.im`, `message.channels`, `message.groups`
+5. **Install to Workspace** → 설치 후 **Bot User OAuth Token** `xoxb-...` 복사
+
+> 상세한 스크린샷 수준 가이드는 [`slack-bot/SLACK_APP_SETUP.md`](slack-bot/SLACK_APP_SETUP.md)를 참고하세요.
+
+---
+
+### 3단계. slack-bot 설치 & `.env` 설정
+
+작업 폴더 안의 `slack-bot`으로 들어가 의존성을 설치하고 `.env`를 채웁니다.
+
+```powershell
+cd C:\work\my-project\slack-bot
+npm install
+Copy-Item .env.example .env   # (Mac/Linux: cp .env.example .env)
+```
+
+`.env`에서 최소 3개 값을 채우면 됩니다.
+
+```env
+SLACK_BOT_TOKEN=xoxb-...                 # 2단계 5)에서 복사한 Bot Token
+SLACK_APP_TOKEN=xapp-...                 # 2단계 2)에서 복사한 App-Level Token
+WORKSPACE_DIR=C:\work\my-project         # 1단계에서 만든 작업 폴더 (.agent 가 있는 곳)
+
+# 선택
+# SLACK_CHANNEL_IDS=C0123456789          # 봇이 들을 채널 ID (미지정 시 DM은 항상 동작)
+# BOT_NAME=My Team Bot
+# GITHUB_TOKEN=ghp_...                    # !issues 명령용 GitHub PAT (repo scope)
+# GITHUB_REPO=your-org/your-repo
+```
+
+> `WORKSPACE_DIR`은 **`.agent/`가 들어있는 작업 폴더**를 가리켜야 합니다. 봇은 이 폴더 기준으로 태스크를 처리하고 git push 합니다.
+
+---
+
+### 4단계. 봇 실행
+
+```powershell
+node index.js
+```
+
+`Socket Mode connected` 로그가 뜨면 성공입니다. 항상 켜두려면 **pm2**로 상시 구동을 권장합니다.
+
+```powershell
+npm install -g pm2
+pm2 start index.js --name giipclaude-bot
+pm2 save
+pm2 logs giipclaude-bot     # 로그 확인
+```
+
+---
+
+### 5단계. 채널에 초대하고 사용하기
+
+봇을 사용할 채널에서 초대한 뒤 멘션하면 됩니다.
+
+```
+/invite @<봇 이름>
+
+@<봇 이름> 설정 페이지에 다크모드 토글 추가해줘
+→ 봇이 요청을 분석해 태스크 계획(ID 포함)을 올림
+
+go 20240601120000
+→ 서브에이전트가 실행 후 git push, 결과 GitHub URL을 회신
+```
+
+기타 명령: `tasklist`(대기 태스크), `cancel <taskID>`, `!issues`, DM으로 직접 대화 등.
+전체 사용법은 [`slack-bot/README.md`](slack-bot/README.md)에 있습니다.
+
+---
 
 > [!TIP]
-> 설치 후 AI 도구(Antigravity, Cursor 등)에게 이렇게 명령해 보세요:
+> Slack 봇 없이 **AI 도구(Antigravity, Cursor 등)로 직접** 쓰고 싶다면, 1단계 복사만으로 충분합니다.
+> AI 도구에게 이렇게 명령해 보세요:
 > **"넌 오케스트레이터야. 메인 지침서(GEMINI.md)를 읽고 현재 태스크를 분석해줘."**
 
 > [!IMPORTANT]
-> **API Key 설정** (자동화 시 필요, 수동 작업 시 불필요):
+> **Gemini API Key 설정** (이미지 생성 등 `.agent` 자동화 시 필요, 수동 작업 시 불필요):
 > `.agent/settings.json.sample`을 `settings.json`으로 복사하고 발급받은 Gemini API Key를 입력하세요.
+> (Slack 봇의 태스크 구동 자체는 Claude CLI를 쓰므로 이 키가 없어도 됩니다.)
 
 ---
 

--- a/readme_en.md
+++ b/readme_en.md
@@ -36,29 +36,144 @@ This agent is the executor of the [**giip FDE Box**](https://giip.littleworld.ne
 
 ---
 
-## 💻 Install the FDE Agent onto your PC
+## 💻 Install the FDE Agent onto your PC — Bring up the Slack bot first
 
-Move to your project folder and transplant the agent files (**excluding the `.git` folder**) to instantly activate the FDE Agent.
+`giip-fde-agent` is a **public repository**. So instead of working inside this repo folder directly,
+the fastest and safest start is to **get the repo → copy the needed files into a folder you'll use as your main workspace → run the Slack bot with that folder as the workspace.**
+This way, when you pull the repo again for updates, it won't mix with your own work.
 
-### Windows (PowerShell)
+Follow the steps below to reach a state where you can **assign work to the FDE Agent from Slack via `@bot <request>`**.
+
+### Prerequisites
+
+- **Node.js 18+** (`node -v`)
+- **Claude CLI** installed and logged in — the bot drives the `claude -p` CLI directly, no Anthropic API Key needed.
+  `claude --version` must work and you must have logged in once (run `claude` and authenticate). → [Claude Code](https://claude.ai/code)
+- **Slack workspace admin rights** (you must be able to install an app)
+
+---
+
+### Step 1. Get the repo & copy into your main work folder
+
+First clone the repo, create **a folder you'll use as your main workspace** (e.g. `C:\work\my-project`), and copy the agent files there (**excluding the `.git` folder**).
+
+#### Windows (PowerShell)
 ```powershell
-# Copy essential files (run inside the giip-fde-agent folder or specify a relative path)
-Copy-Item -Path ".agent", "GEMINI.md", ".cursorrules", "COPILOT_INSTRUCTIONS.md" -Destination "YOUR_PROJECT_PATH" -Recurse -Force
+# 1) Clone the repo (any location)
+git clone https://github.com/LowyShin/giip-fde-agent.git
+
+# 2) Create your main work folder (path is up to you)
+New-Item -ItemType Directory -Force "C:\work\my-project"
+
+# 3) Copy agent + slack-bot files into your work folder
+cd giip-fde-agent
+Copy-Item -Path ".agent", "GEMINI.md", ".cursorrules", "COPILOT_INSTRUCTIONS.md", "slack-bot" -Destination "C:\work\my-project" -Recurse -Force
 ```
 
-### Mac/Linux
+#### Mac/Linux
 ```bash
-# Copy essential files (rsync recommended)
-rsync -av --exclude='.git' .agent GEMINI.md .cursorrules COPILOT_INSTRUCTIONS.md YOUR_PROJECT_PATH/
+# 1) Clone the repo
+git clone https://github.com/LowyShin/giip-fde-agent.git
+
+# 2) Create your main work folder
+mkdir -p ~/work/my-project
+
+# 3) Copy agent + slack-bot files (excluding .git)
+cd giip-fde-agent
+rsync -av --exclude='.git' .agent GEMINI.md .cursorrules COPILOT_INSTRUCTIONS.md slack-bot ~/work/my-project/
 ```
+
+> From here on, do all work in the **copied work folder** (`C:\work\my-project`). Keep the original `giip-fde-agent` folder only for receiving updates.
+
+---
+
+### Step 2. Create a Slack app (Socket Mode)
+
+The bot runs in **Socket Mode** (no public URL needed). Create an app at [api.slack.com/apps](https://api.slack.com/apps) and issue the two tokens below.
+
+1. **Create New App → From scratch**
+2. Enable **Socket Mode** → generate an App-Level Token (scope `connections:write`) → copy `xapp-...`
+3. **OAuth & Permissions → Bot Token Scopes**: `chat:write`, `app_mentions:read`, `channels:history`, `channels:read`, `groups:history`, `im:history`, `im:read`, `im:write`, `users:read`
+4. Enable **Event Subscriptions** → Subscribe to bot events: `app_mention`, `message.im`, `message.channels`, `message.groups`
+5. **Install to Workspace** → after install, copy the **Bot User OAuth Token** `xoxb-...`
+
+> For a screenshot-level detailed guide, see [`slack-bot/SLACK_APP_SETUP.md`](slack-bot/SLACK_APP_SETUP.md).
+
+---
+
+### Step 3. Install slack-bot & configure `.env`
+
+Go into `slack-bot` inside your work folder, install dependencies, and fill in `.env`.
+
+```powershell
+cd C:\work\my-project\slack-bot
+npm install
+Copy-Item .env.example .env   # (Mac/Linux: cp .env.example .env)
+```
+
+Fill in at least three values in `.env`:
+
+```env
+SLACK_BOT_TOKEN=xoxb-...                 # Bot Token copied in Step 2-5
+SLACK_APP_TOKEN=xapp-...                 # App-Level Token copied in Step 2-2
+WORKSPACE_DIR=C:\work\my-project         # the work folder from Step 1 (where .agent lives)
+
+# Optional
+# SLACK_CHANNEL_IDS=C0123456789          # channel IDs the bot listens to (DMs always work if omitted)
+# BOT_NAME=My Team Bot
+# GITHUB_TOKEN=ghp_...                    # GitHub PAT (repo scope) for the !issues command
+# GITHUB_REPO=your-org/your-repo
+```
+
+> `WORKSPACE_DIR` must point to the **work folder containing `.agent/`**. The bot processes tasks and runs git push relative to this folder.
+
+---
+
+### Step 4. Run the bot
+
+```powershell
+node index.js
+```
+
+A `Socket Mode connected` log means success. To keep it always on, running it under **pm2** is recommended.
+
+```powershell
+npm install -g pm2
+pm2 start index.js --name giipclaude-bot
+pm2 save
+pm2 logs giipclaude-bot     # check logs
+```
+
+---
+
+### Step 5. Invite to a channel and use it
+
+Invite the bot to the channel you want, then mention it.
+
+```
+/invite @<bot name>
+
+@<bot name> add a dark mode toggle to the settings page
+→ The bot analyzes the request and posts a task plan (with an ID)
+
+go 20240601120000
+→ A subagent executes, runs git push, and replies with the result's GitHub URL
+```
+
+Other commands: `tasklist` (pending tasks), `cancel <taskID>`, `!issues`, or DM the bot for a direct conversation.
+See [`slack-bot/README.md`](slack-bot/README.md) for the full usage.
+
+---
 
 > [!TIP]
-> After installation, tell your AI tool (Antigravity, Cursor, etc.):
+> If you'd rather use it **directly with AI tools (Antigravity, Cursor, etc.)** without the Slack bot, the copy in Step 1 alone is enough.
+> Tell your AI tool:
 > **"You are the Orchestrator. Read GEMINI.md and analyze the current task."**
 
 > [!IMPORTANT]
-> **API Key Setup** (required for automation, not needed for manual work):
+> **Gemini API Key Setup** (required for `.agent` automation such as image generation, not needed for manual work):
 > Copy `.agent/settings.json.sample` to `settings.json` and enter your issued Gemini API Key.
+> (The Slack bot's task execution itself uses the Claude CLI, so it works even without this key.)
 
 ---
 

--- a/readme_jp.md
+++ b/readme_jp.md
@@ -36,29 +36,144 @@
 
 ---
 
-## 💻 自分のPCに FDE Agent をインストールする
+## 💻 自分のPCに FDE Agent をインストールする — まず Slack ボットを起動する
 
-プロジェクトフォルダに移動し、エージェントファイルを移植（**`.git` フォルダは除く**）すると、即座に FDE Agent が有効になります。
+`giip-fde-agent` は **public リポジトリ**です。したがってこのリポジトリのフォルダ内で直接作業するのではなく、
+**リポジトリを取得 → あなたが作業メインで使うフォルダへ必要ファイルをコピー → そのフォルダをワークスペースとして Slack ボットを起動する**
+のが最も速く安全なスタートです。こうすればアップデート時にリポジトリを再 pull しても、あなたの作業物と混ざりません。
 
-### Windows (PowerShell)
+以下の手順どおりに進めれば、**Slack で `@ボット <依頼>` と話しかけて FDE Agent に仕事を任せられる状態**まで到達します。
+
+### 事前準備 (Prerequisites)
+
+- **Node.js 18+** (`node -v`)
+- **Claude CLI** のインストールとログイン — ボットは Anthropic API Key なしで `claude -p` CLI をそのまま駆動します。
+  `claude --version` が動作し、一度ログイン（`claude` 実行後に認証）済みである必要があります。→ [Claude Code](https://claude.ai/code)
+- **Slack ワークスペースの管理者権限**（アプリをインストールできること）
+
+---
+
+### ステップ1. リポジトリ取得 & 作業メインフォルダへコピー
+
+まずリポジトリをクローンし、**あなたが作業メインで使うフォルダ**（例: `C:\work\my-project`）を作成して、そこへエージェントファイルをコピーします（**`.git` フォルダは除く**）。
+
+#### Windows (PowerShell)
 ```powershell
-# 必須ファイルのコピー (giip-fde-agentフォルダ内で実行、または相対パスを指定)
-Copy-Item -Path ".agent", "GEMINI.md", ".cursorrules", "COPILOT_INSTRUCTIONS.md" -Destination "あなたのプロジェクトパス" -Recurse -Force
+# 1) リポジトリをクローン（任意の場所）
+git clone https://github.com/LowyShin/giip-fde-agent.git
+
+# 2) 作業メインフォルダを作成（パスは自由）
+New-Item -ItemType Directory -Force "C:\work\my-project"
+
+# 3) エージェント + slack-bot ファイルを作業フォルダへコピー
+cd giip-fde-agent
+Copy-Item -Path ".agent", "GEMINI.md", ".cursorrules", "COPILOT_INSTRUCTIONS.md", "slack-bot" -Destination "C:\work\my-project" -Recurse -Force
 ```
 
-### Mac/Linux
+#### Mac/Linux
 ```bash
-# 必須ファイルのコピー (rsync推奨)
-rsync -av --exclude='.git' .agent GEMINI.md .cursorrules COPILOT_INSTRUCTIONS.md あなたのプロジェクトパス/
+# 1) リポジトリをクローン
+git clone https://github.com/LowyShin/giip-fde-agent.git
+
+# 2) 作業メインフォルダを作成
+mkdir -p ~/work/my-project
+
+# 3) エージェント + slack-bot ファイルをコピー (.git は除く)
+cd giip-fde-agent
+rsync -av --exclude='.git' .agent GEMINI.md .cursorrules COPILOT_INSTRUCTIONS.md slack-bot ~/work/my-project/
 ```
+
+> 以降のすべての作業は **コピーした作業フォルダ**（`C:\work\my-project`）で行います。元の `giip-fde-agent` フォルダはアップデート受信用に残しておいてください。
+
+---
+
+### ステップ2. Slack アプリを作成する (Socket Mode)
+
+ボットは公開 URL が不要な **Socket Mode** で動作します。[api.slack.com/apps](https://api.slack.com/apps) でアプリを作成し、以下の2つのトークンを発行してください。
+
+1. **Create New App → From scratch** でアプリ作成
+2. **Socket Mode** を有効化 → App-Level Token を生成（スコープ `connections:write`）→ `xapp-...` をコピー
+3. **OAuth & Permissions → Bot Token Scopes**: `chat:write`, `app_mentions:read`, `channels:history`, `channels:read`, `groups:history`, `im:history`, `im:read`, `im:write`, `users:read`
+4. **Event Subscriptions** を有効化 → Subscribe to bot events: `app_mention`, `message.im`, `message.channels`, `message.groups`
+5. **Install to Workspace** → インストール後 **Bot User OAuth Token** `xoxb-...` をコピー
+
+> スクリーンショットレベルの詳細ガイドは [`slack-bot/SLACK_APP_SETUP.md`](slack-bot/SLACK_APP_SETUP.md) を参照してください。
+
+---
+
+### ステップ3. slack-bot のインストール & `.env` 設定
+
+作業フォルダ内の `slack-bot` に入り、依存関係をインストールして `.env` を埋めます。
+
+```powershell
+cd C:\work\my-project\slack-bot
+npm install
+Copy-Item .env.example .env   # (Mac/Linux: cp .env.example .env)
+```
+
+`.env` で最低3つの値を埋めれば動きます。
+
+```env
+SLACK_BOT_TOKEN=xoxb-...                 # ステップ2-5でコピーした Bot Token
+SLACK_APP_TOKEN=xapp-...                 # ステップ2-2でコピーした App-Level Token
+WORKSPACE_DIR=C:\work\my-project         # ステップ1で作った作業フォルダ (.agent がある場所)
+
+# 任意
+# SLACK_CHANNEL_IDS=C0123456789          # ボットが聞くチャンネルID（未指定でも DM は常に動作）
+# BOT_NAME=My Team Bot
+# GITHUB_TOKEN=ghp_...                    # !issues コマンド用 GitHub PAT (repo scope)
+# GITHUB_REPO=your-org/your-repo
+```
+
+> `WORKSPACE_DIR` は **`.agent/` が入っている作業フォルダ**を指す必要があります。ボットはこのフォルダを基準にタスクを処理し、git push します。
+
+---
+
+### ステップ4. ボットを起動する
+
+```powershell
+node index.js
+```
+
+`Socket Mode connected` のログが出れば成功です。常時起動させるには **pm2** での常駐を推奨します。
+
+```powershell
+npm install -g pm2
+pm2 start index.js --name giipclaude-bot
+pm2 save
+pm2 logs giipclaude-bot     # ログ確認
+```
+
+---
+
+### ステップ5. チャンネルに招待して使う
+
+ボットを使いたいチャンネルに招待してからメンションします。
+
+```
+/invite @<ボット名>
+
+@<ボット名> 設定ページにダークモードトグルを追加して
+→ ボットが依頼を分析し、タスク計画（ID付き）を投稿
+
+go 20240601120000
+→ サブエージェントが実行後 git push し、結果の GitHub URL を返信
+```
+
+その他コマンド: `tasklist`（待機タスク）, `cancel <taskID>`, `!issues`, DM で直接会話 など。
+使い方の全体は [`slack-bot/README.md`](slack-bot/README.md) にあります。
+
+---
 
 > [!TIP]
-> インストール後、AIツール（Antigravity、Cursorなど）に次のように指示してみてください：
+> Slack ボットなしで **AIツール（Antigravity、Cursorなど）で直接**使いたい場合は、ステップ1のコピーだけで十分です。
+> AIツールに次のように指示してみてください：
 > **「君はオーケストレーターだ。GEMINI.mdを読んで、現在のタスクを分析してくれ。」**
 
 > [!IMPORTANT]
-> **API Keyの設定**（自動化に必要、手動作業には不要）:
+> **Gemini API Keyの設定**（画像生成など `.agent` 自動化に必要、手動作業には不要）:
 > `.agent/settings.json.sample` を `settings.json` にコピーし、発行された Gemini API Key を入力してください。
+> （Slack ボットのタスク駆動自体は Claude CLI を使うため、このキーがなくても動きます。）
 
 ---
 


### PR DESCRIPTION
## 개요
`giip-fde-agent`가 public 레포임을 전제로, README의 **"내 PC에 FDE Agent 설치하기"** 섹션을 "`.agent` 복사만으로 끝"에서 **slack-bot을 실제로 띄우는 단계별 가이드**로 재작성했습니다. KO/JA/EN 3개 README에 동일 반영.

## 변경 내용
기존 구조·설명(FDE 소개, How It Works, Key Strengths, 지원 도구, 핵심 역량 등)은 그대로 유지하고, 설치 섹션만 아래 5단계로 확장:

1. **레포 받기 & 작업 메인 폴더로 복사** — `git clone` 후 본인 작업 폴더 생성, `.agent`+`slack-bot` 등 복사(`.git` 제외). 원본은 업데이트 수신용
2. **Slack 앱 만들기** — Socket Mode, Bot/App-Level 토큰, 스코프, 이벤트 (상세는 `slack-bot/SLACK_APP_SETUP.md` 링크)
3. **slack-bot 설치 & `.env`** — `npm install` + 최소 3개 값(`SLACK_BOT_TOKEN`/`SLACK_APP_TOKEN`/`WORKSPACE_DIR`)
4. **실행** — `node index.js` / pm2 상시 구동
5. **채널 초대 & 사용** — `/invite`, `@봇 요청` → `go <taskID>`

추가로 사전 준비(Node 18+, Claude CLI)를 명시하고, "봇 없이 AI 도구만 쓰려면 1단계 복사만으로 충분"과 Gemini API Key 안내는 팁으로 보존.

## 파일
- `README.md` (KO)
- `readme_jp.md` (JA)
- `readme_en.md` (EN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
