### PR TITLE
feat(slack-bot): giip issue 연동 기능 포팅 (라이브 동기화)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ giipdb/
 slack-bot/.bot-threads.json
 slack-bot/.task-state.json
 slack-bot/tasklist.json
+
+# slack-bot giip 계정 시크릿(SK) — 실값 비커밋, *.sample 만 추적
+slack-bot/.secrets/*
+!slack-bot/.secrets/*.sample.json

--- a/slack-bot/.secrets/giip-accounts.sample.json
+++ b/slack-bot/.secrets/giip-accounts.sample.json
@@ -1,0 +1,15 @@
+{
+  "GIIP_API_BASE": "https://giipfaw.azurewebsites.net/api",
+  "default": {
+    "login_id": "YOUR_GIIP_LOGIN_ID",
+    "sk": "YOUR_GIIP_SECRET_KEY",
+    "csn": 0
+  },
+  "channels": {
+    "C0XXXXXXXXX": {
+      "login_id": "YOUR_GIIP_LOGIN_ID",
+      "sk": "YOUR_GIIP_SECRET_KEY",
+      "csn": 0
+    }
+  }
+}

--- a/slack-bot/giip-accounts.js
+++ b/slack-bot/giip-accounts.js
@@ -1,0 +1,80 @@
+/**
+ * giip-accounts.js — Slack 채널별 giip 계정 매핑(로그인ID + SK + csn) 로드/저장.
+ * 설계: docs/DESIGN_slackbot_giip_issue_integration.md §3-2·§3-3. 규칙: .agent/rules/39,40.
+ *
+ * 비밀(SK)은 .secrets/giip-accounts.json(비커밋)에만. 샘플은 giip-accounts.sample.json.
+ * AK 는 저장하지 않는다(로그인마다 바뀜) — 런타임에 giip-api.getAK 로 도출.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const SECRETS_DIR = path.join(__dirname, '.secrets');
+const ACCOUNTS_FILE = path.join(SECRETS_DIR, 'giip-accounts.json');
+const DEFAULT_API_BASE = 'https://giipfaw.azurewebsites.net/api';
+
+function load() {
+  try {
+    return JSON.parse(fs.readFileSync(ACCOUNTS_FILE, 'utf8'));
+  } catch {
+    return { GIIP_API_BASE: DEFAULT_API_BASE, default: null, channels: {} };
+  }
+}
+
+function save(cfg) {
+  fs.mkdirSync(SECRETS_DIR, { recursive: true });
+  fs.writeFileSync(ACCOUNTS_FILE, JSON.stringify(cfg, null, 2));
+}
+
+function apiBase() {
+  return load().GIIP_API_BASE || process.env.GIIP_API_BASE || DEFAULT_API_BASE;
+}
+
+/**
+ * 채널 → 계정 {login_id, sk, csn, apiBase} 해석.
+ * 순서: 채널 매핑 → default → env(GIIP_LOGIN_ID/GIIP_SK/GIIP_CSN). 없으면 null(=미연결).
+ */
+function resolve(channelId) {
+  const cfg = load();
+  const base = cfg.GIIP_API_BASE || process.env.GIIP_API_BASE || DEFAULT_API_BASE;
+  const acct =
+    (channelId && cfg.channels && cfg.channels[channelId]) ||
+    cfg.default ||
+    null;
+  if (acct && acct.login_id && acct.sk) {
+    return { login_id: acct.login_id, sk: acct.sk, csn: acct.csn ?? null, apiBase: base };
+  }
+  if (process.env.GIIP_LOGIN_ID && process.env.GIIP_SK) {
+    return {
+      login_id: process.env.GIIP_LOGIN_ID,
+      sk: process.env.GIIP_SK,
+      csn: process.env.GIIP_CSN ? Number(process.env.GIIP_CSN) : null,
+      apiBase: base,
+    };
+  }
+  return null;
+}
+
+/** giip issue 연결 가능 여부(계정 존재). */
+function isConnected(channelId) {
+  return !!resolve(channelId);
+}
+
+/**
+ * 대화로 계정 설정/변경 → 파일 영속화. channelId 없거나 asDefault=true 면 default 갱신.
+ */
+function setAccount(channelId, { login_id, sk, csn } = {}, asDefault = false) {
+  const cfg = load();
+  cfg.GIIP_API_BASE = cfg.GIIP_API_BASE || DEFAULT_API_BASE;
+  const acct = { login_id, sk };
+  if (csn != null && csn !== '') acct.csn = Number(csn);
+  if (asDefault || !channelId) {
+    cfg.default = acct;
+  } else {
+    cfg.channels = cfg.channels || {};
+    cfg.channels[channelId] = acct;
+  }
+  save(cfg);
+  return acct;
+}
+
+module.exports = { load, save, resolve, isConnected, setAccount, apiBase, ACCOUNTS_FILE };

--- a/slack-bot/giip-api.js
+++ b/slack-bot/giip-api.js
@@ -1,0 +1,172 @@
+/**
+ * giip-api.js — giip API 클라이언트(의존성 없음, 내장 https).
+ * 설계: docs/DESIGN_slackbot_giip_issue_integration.md. 규칙: .agent/rules/39(AK 도출),40(생성 우선).
+ *
+ * 인증: 계정(login_id+sk) → AdminGetAK(giipApi 디스패처) 로 최신 AK 취득·캐시(20h, 401 시 강제 갱신).
+ * 절대 사용자에게 AK 를 요청하지 않는다(rule 39). .env/.secrets 의 login_id+SK 로 도출.
+ */
+const https = require('https');
+const { URL } = require('url');
+const accounts = require('./giip-accounts');
+
+const AK_TTL_MS = 20 * 60 * 60 * 1000; // 20h
+const akCache = new Map(); // login_id → { ak, csn, usn, fetchedAt }
+
+function request(method, urlStr, { headers = {}, body = null, timeoutMs = 30000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const u = new URL(urlStr);
+    const data = body == null ? null : typeof body === 'string' ? body : JSON.stringify(body);
+    const opts = {
+      method,
+      hostname: u.hostname,
+      port: u.port || 443,
+      path: u.pathname + u.search,
+      headers: { ...headers },
+    };
+    if (data) opts.headers['Content-Length'] = Buffer.byteLength(data);
+    const req = https.request(opts, (res) => {
+      let chunks = '';
+      res.on('data', (d) => (chunks += d));
+      res.on('end', () => {
+        let parsed = chunks;
+        try { parsed = JSON.parse(chunks); } catch { /* keep string */ }
+        resolve({ status: res.statusCode, body: parsed, raw: chunks });
+      });
+    });
+    req.on('error', reject);
+    req.setTimeout(timeoutMs, () => req.destroy(new Error('giip-api request timeout')));
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+function form(params) {
+  return Object.entries(params)
+    .filter(([, v]) => v != null)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&');
+}
+
+/** AdminGetAK: 계정(login_id+sk) → 최신 AK. giipApi 디스패처(text=AdminGetAK). */
+async function getAK(account, { force = false } = {}) {
+  const key = account.login_id;
+  const cached = akCache.get(key);
+  if (!force && cached && Date.now() - cached.fetchedAt < AK_TTL_MS) return cached;
+
+  const base = account.apiBase || accounts.apiBase();
+  const bodyStr = form({
+    text: 'AdminGetAK',
+    token: account.sk,
+    usertoken: account.sk,
+    jsondata: JSON.stringify({ uloginid: account.login_id }),
+  });
+  const res = await request('POST', `${base}/giipApi`, {
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: bodyStr,
+  });
+  const rows = Array.isArray(res.body) ? res.body : res.body ? [res.body] : [];
+  const row = rows[0] || {};
+  if (String(row.RstVal) !== '200' || !row.ak) {
+    throw new Error(`AdminGetAK 실패: ${row.Proc_MSG || res.raw || res.status}`);
+  }
+  const entry = { ak: row.ak, csn: row.csn, usn: row.usn, fetchedAt: Date.now() };
+  akCache.set(key, entry);
+  return entry;
+}
+
+/** giipIssues(전용함수) 호출. x-api-key=AK, 401 시 1회 강제 갱신 재시도. */
+async function issueApi(account, method, { query = '', body = null } = {}) {
+  const base = account.apiBase || accounts.apiBase();
+  let ak = (await getAK(account)).ak;
+  const url = `${base}/giipIssues${query}`;
+  let res = await request(method, url, {
+    headers: { 'x-api-key': ak, 'Content-Type': 'application/json' },
+    body,
+  });
+  if (res.status === 401) {
+    ak = (await getAK(account, { force: true })).ak;
+    res = await request(method, url, {
+      headers: { 'x-api-key': ak, 'Content-Type': 'application/json' },
+      body,
+    });
+  }
+  return res;
+}
+
+async function issueGet(account, isn) {
+  const res = await issueApi(account, 'GET', { query: `?isn=${encodeURIComponent(isn)}` });
+  if (res.status !== 200) throw new Error(`issueGet 실패: ${res.body?.error || res.status}`);
+  return res.body?.issue || {};
+}
+
+async function issueList(account, { status = '', csn = '' } = {}) {
+  const q = [];
+  if (status) q.push(`status=${encodeURIComponent(status)}`);
+  if (csn) q.push(`csn=${encodeURIComponent(csn)}`);
+  const res = await issueApi(account, 'GET', { query: q.length ? `?${q.join('&')}` : '' });
+  if (res.status !== 200) throw new Error(`issueList 실패: ${res.body?.error || res.status}`);
+  return res.body?.issues || [];
+}
+
+async function issueCreate(account, { title, content, status = 'IN_PROGRESS', csn, target_lssn = null, agent_workflow = null }) {
+  const res = await issueApi(account, 'POST', {
+    body: { title, content, status, csn: csn ?? account.csn, target_lssn, agent_workflow },
+  });
+  if (res.status !== 200 || !res.body?.isn) throw new Error(`issueCreate 실패: ${res.body?.error || res.status}`);
+  return res.body; // { success, isn, message }
+}
+
+/** PUT 은 전체 덮어쓰기 → read-modify-write 로 미지정 필드 보존(설계 §6). */
+async function issueUpdate(account, fields) {
+  const cur = await issueGet(account, fields.isn);
+  const merged = {
+    isn: fields.isn,
+    title: fields.title ?? cur.title,
+    content: fields.content ?? cur.content,
+    status: fields.status ?? cur.status,
+    csn: fields.csn ?? cur.CSn ?? cur.csn ?? account.csn,
+    target_lssn: fields.target_lssn ?? cur.target_lssn ?? null,
+    agent_workflow: fields.agent_workflow ?? cur.agent_workflow ?? null,
+  };
+  const res = await issueApi(account, 'PUT', { body: merged });
+  if (res.status !== 200) throw new Error(`issueUpdate 실패: ${res.body?.error || res.status}`);
+  return res.body;
+}
+
+async function issueComment(account, isn, content) {
+  const base = account.apiBase || accounts.apiBase();
+  let ak = (await getAK(account)).ak;
+  const doPost = (token) =>
+    request('POST', `${base}/giipIssueComments`, {
+      headers: { 'x-api-key': token, 'Content-Type': 'application/json' },
+      body: { isn: Number(isn), content },
+    });
+  let res = await doPost(ak);
+  if (res.status === 401) { ak = (await getAK(account, { force: true })).ak; res = await doPost(ak); }
+  if (res.status !== 200) throw new Error(`issueComment 실패: ${res.body?.error || res.status}`);
+  return res.body;
+}
+
+/** 범용: 임의 giip API 를 giipApi 디스패처로 호출(text=Verb). */
+async function apiCall(account, verb, jsondata = null) {
+  const base = account.apiBase || accounts.apiBase();
+  const ak = (await getAK(account)).ak;
+  const params = { text: verb, token: ak, usertoken: ak };
+  if (jsondata) params.jsondata = typeof jsondata === 'string' ? jsondata : JSON.stringify(jsondata);
+  const res = await request('POST', `${base}/giipApi`, {
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: form(params),
+  });
+  return res.body;
+}
+
+module.exports = {
+  getAK,
+  issueGet,
+  issueList,
+  issueCreate,
+  issueUpdate,
+  issueComment,
+  apiCall,
+  _akCache: akCache,
+};

--- a/slack-bot/giip-commands.js
+++ b/slack-bot/giip-commands.js
@@ -1,0 +1,113 @@
+/**
+ * giip-commands.js — Slack `giip ...` 커맨드 핸들러 (자립 모듈).
+ * index.js 는 한 줄 훅으로 연결:
+ *   const gc = await handleGiipCommand(text, channelId); if (gc.handled) { await reply(gc.text); return; }
+ * 설계: docs/DESIGN_slackbot_giip_issue_integration.md §5. 규칙 39/40.
+ */
+const accounts = require('./giip-accounts');
+const giip = require('./giip-api');
+
+function code(obj, max = 1800) {
+  return '```\n' + JSON.stringify(obj, null, 2).slice(0, max) + '\n```';
+}
+
+/**
+ * @returns {Promise<{handled:boolean, text?:string}>}
+ */
+async function handleGiipCommand(rawText, channelId) {
+  const text = (rawText || '').trim();
+  const m = text.match(/^giip\s+(\S+)\s*([\s\S]*)$/i);
+  if (!m) return { handled: false };
+  const sub = m[1].toLowerCase();
+  const rest = (m[2] || '').trim();
+
+  // ── giip account ... — 채널 계정 매핑(대화로 변경 → .secrets 영속화) ──
+  if (sub === 'account') {
+    const setM = rest.match(/^set(-default)?\s+(\S+)\s+(\S+)\s*(\d+)?/i);
+    if (setM) {
+      const asDefault = !!setM[1];
+      const login_id = setM[2];
+      const sk = setM[3];
+      const csn = setM[4] || null;
+      accounts.setAccount(asDefault ? null : channelId, { login_id, sk, csn }, asDefault);
+      return {
+        handled: true,
+        text: `✅ giip 계정 저장(${asDefault ? 'default' : channelId}) — login=${login_id}${csn ? `, csn=${csn}` : ''}.\n⚠️ 보안: SK 가 포함된 이 메시지는 삭제하세요.`,
+      };
+    }
+    if (/^(show|status)/i.test(rest)) {
+      const acct = accounts.resolve(channelId);
+      return {
+        handled: true,
+        text: acct ? `login=${acct.login_id}, csn=${acct.csn ?? '-'} (SK 숨김)` : '계정 미설정',
+      };
+    }
+    return {
+      handled: true,
+      text: '사용법: `giip account set <login_id> <sk> [csn]` | `set-default <login_id> <sk> [csn]` | `show`',
+    };
+  }
+
+  const acct = accounts.resolve(channelId);
+  if (!acct) {
+    return {
+      handled: true,
+      text: '⚠️ giip 계정 미설정. `giip account set <login_id> <sk> [csn]` 로 등록하세요(DM 권장).',
+    };
+  }
+
+  // ── giip issue ... ──
+  if (sub === 'issue') {
+    const im = rest.match(/^(\w+)?\s*([\s\S]*)$/);
+    const action = (im && im[1] ? im[1] : 'list').toLowerCase();
+    const arg = im ? (im[2] || '').trim() : '';
+    try {
+      if (action === 'new' || action === 'create') {
+        const title = arg.replace(/^["']|["']$/g, '').trim() || '(무제)';
+        const r = await giip.issueCreate(acct, { title, content: title, status: 'IN_PROGRESS' });
+        return { handled: true, text: `✅ 이슈 생성 #${r.isn} — ${title}` };
+      }
+      if (action === 'done') { await giip.issueUpdate(acct, { isn: Number(arg), status: 'DONE' }); return { handled: true, text: `✅ #${arg} → DONE` }; }
+      if (action === 'review') { await giip.issueUpdate(acct, { isn: Number(arg), status: 'REVIEW' }); return { handled: true, text: `✅ #${arg} → REVIEW` }; }
+      if (action === 'progress' || action === 'start') { await giip.issueUpdate(acct, { isn: Number(arg), status: 'IN_PROGRESS' }); return { handled: true, text: `✅ #${arg} → IN_PROGRESS` }; }
+      if (action === 'get' || action === 'show') { const i = await giip.issueGet(acct, Number(arg)); return { handled: true, text: code(i, 1500) }; }
+      if (action === 'comment') {
+        const cm = arg.match(/^(\d+)\s+([\s\S]+)$/);
+        if (cm) { await giip.issueComment(acct, Number(cm[1]), cm[2]); return { handled: true, text: `✅ #${cm[1]} 코멘트 추가` }; }
+        return { handled: true, text: '사용법: `giip issue comment <isn> <내용>`' };
+      }
+      if (action === 'list') {
+        const list = await giip.issueList(acct, { status: arg || '', csn: acct.csn || '' });
+        return {
+          handled: true,
+          text: list.length ? list.slice(0, 20).map((i) => `#${i.isn} [${i.status}] ${i.title}`).join('\n') : '(이슈 없음)',
+        };
+      }
+      return { handled: true, text: '사용법: `giip issue new "<title>"` | `list [status]` | `get <isn>` | `done|review|progress <isn>` | `comment <isn> <text>`' };
+    } catch (e) {
+      return { handled: true, text: `❌ ${e.message}` };
+    }
+  }
+
+  // ── giip api <Verb> [jsondata] — 범용 giip API 호출 ──
+  if (sub === 'api') {
+    const am = rest.match(/^(\S+)\s*([\s\S]*)$/);
+    if (!am) return { handled: true, text: '사용법: `giip api <Verb> [jsondata]`' };
+    const verb = am[1];
+    let jsondata = null;
+    const jsonPart = (am[2] || '').trim();
+    if (jsonPart) {
+      try { jsondata = JSON.parse(jsonPart); } catch { return { handled: true, text: 'jsondata JSON 파싱 실패' }; }
+    }
+    try {
+      const r = await giip.apiCall(acct, verb, jsondata);
+      return { handled: true, text: code(r) };
+    } catch (e) {
+      return { handled: true, text: `❌ ${e.message}` };
+    }
+  }
+
+  return { handled: false };
+}
+
+module.exports = { handleGiipCommand };

--- a/slack-bot/giip-task.js
+++ b/slack-bot/giip-task.js
@@ -1,0 +1,38 @@
+/**
+ * giip-task.js — task-manager 생명주기 ↔ giip issue 연동(얇은 훅, best-effort).
+ * rule 40: 연결 시 giip issue 우선 등록, 미연결/실패 시 null → 로컬 타임스탬프 폴백.
+ * 설계: docs/DESIGN_slackbot_giip_issue_integration.md §4.
+ * 모든 함수는 절대 throw 하지 않는다(봇 무중단). 실패는 로그 + null/no-op.
+ */
+const accounts = require('./giip-accounts');
+const giip = require('./giip-api');
+
+/** 태스크 생성 시: 연결되어 있으면 issue 생성(IN_PROGRESS) → isn. 아니면 null(로컬 폴백). */
+async function maybeCreateIssue(channelId, title, content) {
+  const acct = accounts.resolve(channelId);
+  if (!acct) return null;
+  try {
+    const r = await giip.issueCreate(acct, {
+      title: (title || '(무제)').slice(0, 200),
+      content: (content || title || '').slice(0, 8000),
+      status: 'IN_PROGRESS',
+    });
+    return r && r.isn ? Number(r.isn) : null;
+  } catch (e) {
+    console.error('[giip-task] issue 생성 실패(로컬 폴백):', e.message);
+    return null;
+  }
+}
+
+/** 완료/에러 시: 코멘트 + 상태전이(best-effort, 실패해도 무시). */
+async function maybeFinish(channelId, isn, status, comment) {
+  if (!isn) return;
+  const acct = accounts.resolve(channelId);
+  if (!acct) return;
+  try { if (comment) await giip.issueComment(acct, isn, comment); }
+  catch (e) { console.error('[giip-task] comment 실패:', e.message); }
+  try { if (status) await giip.issueUpdate(acct, { isn, status }); }
+  catch (e) { console.error('[giip-task] status 실패:', e.message); }
+}
+
+module.exports = { maybeCreateIssue, maybeFinish };

--- a/slack-bot/index.js
+++ b/slack-bot/index.js
@@ -790,6 +790,13 @@ async function handleDM({ channelId, ts, threadTs, text, conversations, workDir 
   const replyTs = threadTs || undefined;
   const cmd = text.trim().toLowerCase();
 
+  // ── giip 커맨드 (giip api|issue|account) — DM 은 특히 account set(SK) 에 안전 ──
+  try {
+    const { handleGiipCommand } = require('./giip-commands');
+    const gc = await handleGiipCommand(text.trim(), channelId);
+    if (gc.handled) { await postMessage(channelId, gc.text, replyTs); return; }
+  } catch (e) { console.error('[Bot] giip command error:', e.message); }
+
   if (cmd === '!help') {
     await postMessage(channelId, [
       '*giipclaude AI — DM コマンド一覧*',
@@ -797,6 +804,17 @@ async function handleDM({ channelId, ts, threadTs, text, conversations, workDir 
       '• `!issues refresh` — Issue 強制更新',
       '• `!klayer <キーワード>` — K-Layer 知識検索',
       '• `!reset` — 会話履歴リセット',
+      '',
+      '*giip issue 連携:*',
+      '• `giip account set <login_id> <sk> [csn]` — チャンネル連携（DM推奨・SK含むので channel では避ける）',
+      '• `giip account show` — 現在の連携アカウント表示',
+      '• `giip issue list [status]` — イシュー一覧',
+      '• `giip issue get <isn>` — イシュー詳細',
+      '• `giip issue new "<title>"` — イシュー新規作成',
+      '• `giip issue done|review|progress <isn>` — ステータス変更',
+      '• `giip issue comment <isn> <text>` — コメント追加',
+      '• `giip api <Verb> [jsondata]` — 汎用 giip API 呼び出し',
+      '',
       'チャンネルで `@ボット名 要求内容` と書くと Task ワークフローが始まります。',
     ].join('\n'), replyTs);
     return;
@@ -945,6 +963,13 @@ async function startTaskExecution(pendingKey, pendingTask, channelId, replyTs, t
         );
         await postLong(channelId, checkAllRepoStatus(), replyTs);
       }
+
+      // ── giip issue 통일(rule 40): 완료 시 코멘트 + REVIEW 전이(best-effort). ──
+      try {
+        const gt = require('./giip-task');
+        const cmt = githubUrl ? `✅ 작업 완료\n결과: ${githubUrl}` : '✅ 작업 완료(로컬, git push 실패)';
+        await gt.maybeFinish(channelId, pendingTask.isn, 'REVIEW', cmt);
+      } catch (e) { console.error('[Bot] giip finish 훅 오류:', e.message); }
     },
     onError: async (err, resultFile) => {
       const ts2 = loadJSON(TASK_STATE_FILE, {});
@@ -960,6 +985,12 @@ async function startTaskExecution(pendingKey, pendingTask, channelId, replyTs, t
         `❌ *작업 에러* (\`${pendingTask.taskId}\`): ${err.message}${githubUrl ? `\n📄 에러 로그: ${githubUrl}` : ''}`,
         replyTs
       );
+
+      // ── giip issue 통일(rule 40): 에러 시 코멘트 + REVIEW 전이(best-effort). ──
+      try {
+        const gt = require('./giip-task');
+        await gt.maybeFinish(channelId, pendingTask.isn, 'REVIEW', `❌ 작업 에러: ${err.message}${githubUrl ? `\n로그: ${githubUrl}` : ''}`);
+      } catch (e) { console.error('[Bot] giip finish 훅 오류:', e.message); }
     },
   }, workDir);
 }
@@ -973,6 +1004,13 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
   // バッククォート・全角スペース等を除去してからコマンド判定
   const cmd = text.trim().replace(/`/g, '').replace(/\s+/g, ' ').toLowerCase();
   console.log(`[Bot] handleChannelMention cmd="${cmd}" convKey="${convKey}"`);
+
+  // ── giip 커맨드 (giip api|issue|account) ──
+  try {
+    const { handleGiipCommand } = require('./giip-commands');
+    const gc = await handleGiipCommand(text.trim(), channelId);
+    if (gc.handled) { await postMessage(channelId, gc.text, replyTs); return; }
+  } catch (e) { console.error('[Bot] giip command error:', e.message); }
 
   // ── 내장 명령어 ─────────────────────────────────────────────────────────────
   if (cmd === '!help') {
@@ -1002,6 +1040,16 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
       '    ‣ `<プロジェクト> <名> 실행` / `<プロジェクト> /<名>` / `<プロジェクト> <名>`',
       '    例) `giipprj wf errorproc` = `giipprj errorproc 실행` = `giipprj /errorproc` = `giipprj workflow errorproc`',
       '    ※ 「<名> 실행」「<名>」の形は実在ワークフロー名と完全一致した時のみ実行（誤爆防止）',
+      '',
+      '*giip issue 連携:*',
+      '• `giip account set <login_id> <sk> [csn]` — チャンネル連携（SK含むので DM 推奨）',
+      '• `giip account show` — 現在の連携アカウント表示',
+      '• `giip issue list [status]` — イシュー一覧',
+      '• `giip issue get <isn>` — イシュー詳細',
+      '• `giip issue new "<title>"` — イシュー新規作成',
+      '• `giip issue done|review|progress <isn>` — ステータス変更',
+      '• `giip issue comment <isn> <text>` — コメント追加',
+      '• `giip api <Verb> [jsondata]` — 汎用 giip API 呼び出し',
       '',
       '*情報:*',
       '• `!issues` — GitHub Issue 一覧',
@@ -1513,8 +1561,17 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
   saveJSON(TASK_STATE_FILE, taskState);
   tm.addToTasklist(taskId, taskTitle, taskSummary, taskRequestText);
 
+  // ── giip issue 통일(rule 40): 연결 시 issue 우선 등록(IN_PROGRESS). 실패/미연결 시 로컬 태스크만. ──
+  let giipIsn = null;
+  try {
+    const gt = require('./giip-task');
+    giipIsn = await gt.maybeCreateIssue(channelId, taskTitle, planContent);
+    if (giipIsn) { taskState.pending[convKey].isn = giipIsn; saveJSON(TASK_STATE_FILE, taskState); }
+  } catch (e) { console.error('[Bot] giip issue 등록 훅 오류:', e.message); }
+  const isnLine = giipIsn ? `\n🔗 giip issue #${giipIsn} (IN_PROGRESS)` : '';
+
   await postLong(channelId,
-    `📋 *Task 分析完了* (\`${taskId}\`)${closedNotice}\n\n${planContent}\n\n---\n*実行: \`go ${taskId}\` / キャンセル: \`cancel ${taskId}\`*`,
+    `📋 *Task 分析完了* (\`${taskId}\`)${isnLine}${closedNotice}\n\n${planContent}\n\n---\n*実行: \`go ${taskId}\` / キャンセル: \`cancel ${taskId}\`*`,
     replyTs
   );
 }


### PR DESCRIPTION
## 배경
라이브 운용본(`Lowyworkenv/slack-bot`)에는 giip issue 연동 기능이 있으나, 템플릿(`giip-fde-agent/slack-bot`)에는 관련 파일(`giip-commands.js`, `giip-api.js`, `giip-accounts.js`, `giip-task.js`)이 전혀 없어 giip 명령·이슈 등록이 불가능했다. 라이브와 동기화하기 위해 기능 전체를 이식한다.

## 변경
- **신규 파일**: `giip-api.js`(giip API 클라이언트, SK→AK 도출), `giip-accounts.js`(채널별 계정 매핑), `giip-commands.js`(`giip account|issue|api` 커맨드), `giip-task.js`(태스크 생명주기 ↔ issue 훅)
- **index.js 배선**:
  - DM/채널 핸들러에 `handleGiipCommand` 훅 추가
  - `!help` 양쪽 블록에 `giip issue 連携` 섹션 추가
  - 태스크 생성 시 `maybeCreateIssue`로 issue 등록(IN_PROGRESS) → Slack에 `🔗 giip issue #<isn>` 표시
  - 완료/에러 시 `maybeFinish`로 코멘트 + REVIEW 전이
- **시크릿 관리**: `.gitignore`에 `slack-bot/.secrets/*` 추가(실값 비커밋), `*.sample.json`만 추적. `giip-accounts.sample.json` 템플릿 제공

## 안전장치
- 모든 giip 훅은 채널↔계정 매핑이 없으면 조용히 `null` 폴백(봇 무중단). 연결 안 된 채널은 기존과 동일하게 로컬 태스크만 생성.
- 실 SK는 커밋되지 않음(staged 검증 완료).

## 검증
- `node --check` 전 파일 통과
- 로직: 라이브 구현을 그대로 이식(구조 차이는 fde-agent의 기존 태스크 흐름에 맞춰 배선)

## 반영
- 사용하려면 `slack-bot/.secrets/giip-accounts.json` 생성(샘플 참고) 후 봇 재시작 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)