### PR TITLE
feat(slack-bot): 프로젝트별 CSN 라우팅 + 'giip project' 매핑 관리 커맨드

### DIFF
--- a/slack-bot/README.md
+++ b/slack-bot/README.md
@@ -110,6 +110,30 @@ If `PROJECTS_ROOT` contains multiple projects, prefix the request with the proje
 ```
 → Switches working directory to `PROJECTS_ROOT/myapp` for this request
 
+### Per-project giip CSN routing
+
+Register a giip issue under a specific project's **CSN** by prefixing with the project name:
+
+```
+@giipclaude myapp issue 등록 <내용>
+```
+→ Registers a giip issue with the CSN mapped to `myapp` in `project-csn.json`
+(falls back to the account's default CSN if the project is not mapped).
+
+Manage the mapping from Slack (no restart needed — `project-csn.json` is re-read each call):
+
+| Command | Action |
+| --- | --- |
+| `giip project set <projectName> <csn>` | Add/update a name→CSN mapping |
+| `giip project list` | List all mappings |
+| `giip project del <projectName>` | Remove a mapping |
+
+The name is lowercased on save. A project name works even without a matching
+`PROJECTS_ROOT/<name>` folder — if it is in `project-csn.json`, the CSN still routes
+(working directory then safely stays at `BASE_DIR`). Implemented in `config.js`
+(`resolveProjectCsn` / `setProjectCsn` / `listProjectCsn` / `deleteProjectCsn`) and
+`giip-commands.js` (`giip project`).
+
 ### Q&A
 
 ```

--- a/slack-bot/config.js
+++ b/slack-bot/config.js
@@ -22,6 +22,7 @@ const AGENT_DIR       = path.join(BASE_DIR, '.agent');           // 기본 .agen
 const HISTORY_FILE    = path.join(__dirname, '.conversations.json');
 const TASK_STATE_FILE = path.join(__dirname, '.task-state.json');
 const BOT_THREADS_FILE = path.join(__dirname, '.bot-threads.json');
+const PROJECT_CSN_FILE = path.join(__dirname, 'project-csn.json');
 
 // ── botUserId (main() で auth.test 後にセット、processMessage / socket handler で参照) ──
 let botUserId = null;
@@ -40,20 +41,98 @@ function getAgentDir(workDir) {
 // そのフォルダを workDir として返し、プレフィックスを除去した本文を返す
 function parseProjectPrefix(text) {
   const words = text.trim().split(/\s+/);
-  if (words.length < 1) return { workDir: BASE_DIR, cleanText: text };
+  if (words.length < 1) return { workDir: BASE_DIR, cleanText: text, projectName: null };
   // 助詞・接尾語を除去してプロジェクト名を抽出 (giipprj에서 → giipprj)
   const raw = words[0];
   const candidate = raw.toLowerCase().replace(/(에서|에서는|에서도|에서만|에게서|한테서|의|에|는|이|가|를|을|로|으로|와|과|도|만|까지|부터|처럼|라고|이라고|에서라도|에도)$/u, '');
   const projectDir = path.join(PROJECTS_ROOT, candidate);
+  // 認識したプレフィックス（助詞含む）を除いた本文を返すヘルパ
+  const stripPrefix = () => {
+    const suffix = raw.slice(candidate.length); // 除去した助詞部分
+    const rest = suffix ? [suffix, ...words.slice(1)] : words.slice(1);
+    return rest.join(' ').trim() || text;
+  };
   try {
     if (fs.statSync(projectDir).isDirectory()) {
-      const suffix = raw.slice(candidate.length); // 除去した助詞部分
-      const rest = suffix ? [suffix, ...words.slice(1)] : words.slice(1);
       console.log(`[Bot] プロジェクト切り替え: ${projectDir}`);
-      return { workDir: projectDir, cleanText: rest.join(' ').trim() || text };
+      return { workDir: projectDir, cleanText: stripPrefix(), projectName: candidate };
     }
   } catch {}
-  return { workDir: BASE_DIR, cleanText: text };
+  // フォルダは無いが project-csn.json に登録済みのプロジェクト名なら、CSN ルーティング用に
+  // projectName だけ解決する。workDir は cwd として使われるため安全な BASE_DIR に固定し、
+  // コマンド実行が存在しないフォルダを cwd にするのを防ぐ（CSN ルーティングのみ有効化）。
+  if (candidate && Object.prototype.hasOwnProperty.call(loadProjectCsnMap(), candidate)) {
+    console.log(`[Bot] プロジェクト名(フォルダ無し) 認識: ${candidate} → CSN ルーティング`);
+    return { workDir: BASE_DIR, cleanText: stripPrefix(), projectName: candidate };
+  }
+  return { workDir: BASE_DIR, cleanText: text, projectName: null };
+}
+
+// ── プロジェクト名 → giip csn マッピング（project-csn.json 駆動） ──────────────
+// `<プロジェクト名> issue 등록 <内容>` を、そのプロジェクトの csn で登録するための対応表。
+// ハードコードせず project-csn.json で管理し、呼び出しごとに読み直す（再起動なしで反映）。
+function loadProjectCsnMap() {
+  try {
+    const j = JSON.parse(fs.readFileSync(PROJECT_CSN_FILE, 'utf8'));
+    return (j && j.map) || {};
+  } catch {
+    return {};
+  }
+}
+
+// workDir（またはプロジェクト名）→ csn(Number) or null。未登録なら null を返し、
+// 呼び出し側は issueCreate 内の `csn ?? account.csn` で既定 csn にフォールバックする。
+function resolveProjectCsn(workDirOrName) {
+  if (!workDirOrName) return null;
+  const name = path.basename(String(workDirOrName)).toLowerCase();
+  const v = loadProjectCsnMap()[name];
+  return (v === 0 || v) ? Number(v) : null;
+}
+
+// ── project-csn.json の読み書き（Slack `giip project` コマンドから利用） ──────
+// _comment 等 map 以外のフィールドを保存したまま map だけ更新する。読み込みは
+// loadProjectCsnMap と同じく毎回読み直すので再起動なしで即時反映される。
+function readProjectCsnFile() {
+  try {
+    const j = JSON.parse(fs.readFileSync(PROJECT_CSN_FILE, 'utf8'));
+    return (j && typeof j === 'object') ? j : {};
+  } catch {
+    return {};
+  }
+}
+function writeProjectCsnFile(obj) {
+  fs.writeFileSync(PROJECT_CSN_FILE, JSON.stringify(obj, null, 2) + '\n', 'utf8');
+}
+
+// 全マッピングを { name: csn } で返す。
+function listProjectCsn() {
+  return loadProjectCsnMap();
+}
+
+// プロジェクト名 → csn を追加/更新。name は小文字化して保存（parseProjectPrefix と整合）。
+function setProjectCsn(name, csn) {
+  const key = String(name || '').trim().toLowerCase();
+  const n = Number(csn);
+  if (!key) throw new Error('프로젝트명이 필요합니다.');
+  if (!Number.isInteger(n)) throw new Error('csn 은 정수여야 합니다.');
+  const j = readProjectCsnFile();
+  if (!j.map || typeof j.map !== 'object') j.map = {};
+  j.map[key] = n;
+  writeProjectCsnFile(j);
+  return { name: key, csn: n };
+}
+
+// プロジェクト名のマッピングを削除。存在して削除したら true、無ければ false。
+function deleteProjectCsn(name) {
+  const key = String(name || '').trim().toLowerCase();
+  if (!key) return false;
+  const j = readProjectCsnFile();
+  if (j.map && Object.prototype.hasOwnProperty.call(j.map, key)) {
+    delete j.map[key];
+    writeProjectCsnFile(j);
+    return true;
+  }
+  return false;
 }
 
 module.exports = {
@@ -71,4 +150,8 @@ module.exports = {
   setBotUserId,
   getAgentDir,
   parseProjectPrefix,
+  resolveProjectCsn,
+  listProjectCsn,
+  setProjectCsn,
+  deleteProjectCsn,
 };

--- a/slack-bot/giip-commands.js
+++ b/slack-bot/giip-commands.js
@@ -6,6 +6,7 @@
  */
 const accounts = require('./giip-accounts');
 const giip = require('./giip-api');
+const config = require('./config');
 
 function code(obj, max = 1800) {
   return '```\n' + JSON.stringify(obj, null, 2).slice(0, max) + '\n```';
@@ -46,6 +47,40 @@ async function handleGiipCommand(rawText, channelId) {
       handled: true,
       text: '사용법: `giip account set <login_id> <sk> [csn]` | `set-default <login_id> <sk> [csn]` | `show`',
     };
+  }
+
+  // ── giip project ... — 프로젝트명 ↔ csn 매핑 관리(project-csn.json, 재시작 불필요) ──
+  //   giip 계정과 무관하므로 account 확인 게이트보다 먼저 처리한다.
+  //   `<프로젝트명> issue 등록 <내용>` 이 어떤 csn 으로 등록되는지를 여기서 관리.
+  if (sub === 'project' || sub === 'proj' || sub === 'csn') {
+    const pm = rest.match(/^(set|add|del|delete|rm|remove|list|ls|show)?\s*([\s\S]*)$/i);
+    const action = (pm && pm[1] ? pm[1].toLowerCase() : 'list');
+    const pargs = pm ? (pm[2] || '').trim() : '';
+    const USAGE = '사용법: `giip project set <프로젝트명> <csn>` | `giip project list` | `giip project del <프로젝트명>`';
+    try {
+      if (action === 'set' || action === 'add') {
+        const sm = pargs.match(/^(\S+)\s+(-?\d+)$/);
+        if (!sm) return { handled: true, text: USAGE };
+        const { name, csn } = config.setProjectCsn(sm[1], sm[2]);
+        return {
+          handled: true,
+          text: `✅ 프로젝트 CSN 매핑 저장: \`${name}\` → csn ${csn}\n이제 \`${name} issue 등록 <내용>\` 은 csn ${csn} 로 등록됩니다(봇 재시작 불필요).`,
+        };
+      }
+      if (action === 'del' || action === 'delete' || action === 'rm' || action === 'remove') {
+        const name = pargs.split(/\s+/)[0];
+        if (!name) return { handled: true, text: USAGE };
+        const ok = config.deleteProjectCsn(name);
+        return { handled: true, text: ok ? `✅ 매핑 삭제: \`${name.toLowerCase()}\`` : `⚠️ \`${name.toLowerCase()}\` 매핑이 없습니다.` };
+      }
+      // list / ls / show / (인자 없음)
+      const map = config.listProjectCsn();
+      const keys = Object.keys(map);
+      const body = keys.length ? keys.map((k) => `• \`${k}\` → csn ${map[k]}`).join('\n') : '(등록된 매핑 없음)';
+      return { handled: true, text: `📋 프로젝트 → CSN 매핑 (project-csn.json)\n${body}\n\n${USAGE}` };
+    } catch (e) {
+      return { handled: true, text: `❌ ${e.message}\n${USAGE}` };
+    }
   }
 
   const acct = accounts.resolve(channelId);

--- a/slack-bot/giip-task.js
+++ b/slack-bot/giip-task.js
@@ -7,8 +7,9 @@
 const accounts = require('./giip-accounts');
 const giip = require('./giip-api');
 
-/** 태스크 생성 시: 연결되어 있으면 issue 생성(IN_PROGRESS) → isn. 아니면 null(로컬 폴백). */
-async function maybeCreateIssue(channelId, title, content) {
+/** 태스크 생성 시: 연결되어 있으면 issue 생성(IN_PROGRESS) → isn. 아니면 null(로컬 폴백).
+ *  csn: 프로젝트명 기반 매핑(config.resolveProjectCsn) 결과. null 이면 account 기본 csn 로 폴백. */
+async function maybeCreateIssue(channelId, title, content, csn = null) {
   const acct = accounts.resolve(channelId);
   if (!acct) return null;
   try {
@@ -16,6 +17,7 @@ async function maybeCreateIssue(channelId, title, content) {
       title: (title || '(무제)').slice(0, 200),
       content: (content || title || '').slice(0, 8000),
       status: 'IN_PROGRESS',
+      csn,
     });
     return r && r.isn ? Number(r.isn) : null;
   } catch (e) {
@@ -36,3 +38,4 @@ async function maybeFinish(channelId, isn, status, comment) {
 }
 
 module.exports = { maybeCreateIssue, maybeFinish };
+

--- a/slack-bot/handlers.js
+++ b/slack-bot/handlers.js
@@ -333,7 +333,7 @@ async function startTaskExecution(pendingKey, pendingTask, channelId, replyTs, t
 }
 
 // ── チャンネル Mention 処理 (Task ワークフロー) ───────────────────────────────
-async function handleChannelMention({ channelId, ts, threadTs, text, workDir = BASE_DIR }) {
+async function handleChannelMention({ channelId, ts, threadTs, text, workDir = BASE_DIR, projectName = null }) {
   const convKey = `${channelId}:${threadTs || ts}`;
   const replyTs = threadTs || ts;
   const taskState = loadJSON(TASK_STATE_FILE, { pending: {}, running: {} });
@@ -342,12 +342,51 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
   const cmd = text.trim().replace(/`/g, '').replace(/\s+/g, ' ').toLowerCase();
   console.log(`[Bot] handleChannelMention cmd="${cmd}" convKey="${convKey}"`);
 
-  // ── giip 커맨드 (giip api|issue|account) ──
+  // ── giip 커맨드 (giip api|issue|account|project) ──
   try {
     const { handleGiipCommand } = require('./giip-commands');
     const gc = await handleGiipCommand(text.trim(), channelId);
     if (gc.handled) { await postMessage(channelId, gc.text, replyTs); return; }
   } catch (e) { console.error('[Bot] giip command error:', e.message); }
+
+  // ── "issue 등록 <내용>" — 分類器を通さず明示的に giip issue として登録 ──────
+  //   利用形: `<プロジェクト名> issue 등록 <内容>` / `issue 등록 <内容>`
+  //   (プロジェクト名は parseProjectPrefix で workDir/projectName に解決済み → text は接頭辞除去済み)
+  //   csn は project-csn.json のマッピング(projectName)で決定。未登録なら account 既定 csn にフォールバック。
+  //   区切り(空白 / コロン / 文字列末)を必須にして「issue 등록됐어?」等の質問誤爆を防ぐ
+  //   (JS の \b は ASCII 専用でハングル境界を検出できないため明示的に区切りを要求)。
+  const issueTrigger = /^(?:issue|이슈|イシュー)\s*(?:등록|登録|register)(?:\s+|\s*[:：]\s*|$)/i;
+  if (issueTrigger.test(text.trim())) {
+    const body = text.trim().replace(issueTrigger, '').trim();
+    if (!body) {
+      await postMessage(channelId, '사용법: `<프로젝트> issue 등록 <내용>` — 내용을 그대로 giip issue 로 등록합니다.', replyTs);
+      return;
+    }
+    const title = body.split(/\r?\n/)[0].slice(0, 200).trim() || '(무제)';
+    try {
+      const giipAccounts = require('./giip-accounts');
+      const giip = require('./giip-api');
+      const acct = giipAccounts.resolve(channelId);
+      if (!acct) {
+        await postMessage(channelId,
+          '⚠️ giip 계정 미설정입니다. `giip account set <login_id> <sk> [csn]` 로 먼저 등록하세요(SK 포함이라 DM 권장).',
+          replyTs);
+        return;
+      }
+      const csn = config.resolveProjectCsn(projectName || workDir);
+      const r = await giip.issueCreate(acct, { title, content: body.slice(0, 8000), status: 'PENDING', csn });
+      const isn = r && r.isn ? Number(r.isn) : null;
+      await postMessage(channelId,
+        isn
+          ? `✅ giip issue #${isn} 등록 완료 (PENDING · csn=${csn ?? acct.csn ?? '-'})\n• 제목: ${title}`
+          : '⚠️ issue 등록 응답에 isn 이 없습니다. 계정/CSN 설정을 확인하세요.',
+        replyTs);
+    } catch (e) {
+      console.error('[Bot] issue 등록 실패:', e.message);
+      await postMessage(channelId, `❌ issue 등록 실패: ${e.message}`, replyTs);
+    }
+    return;
+  }
 
   // ── 내장 명령어 ─────────────────────────────────────────────────────────────
   if (cmd === '!help') {
@@ -902,7 +941,8 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
   let giipIsn = null;
   try {
     const gt = require('./giip-task');
-    giipIsn = await gt.maybeCreateIssue(channelId, taskTitle, planContent);
+    // csn 은 처음 언급한 프로젝트명(projectName, 폴더 없어도 해석) 기준(project-csn.json). 없으면 account.csn 폴백.
+    giipIsn = await gt.maybeCreateIssue(channelId, taskTitle, planContent, config.resolveProjectCsn(projectName || workDir));
     if (giipIsn) { taskState.pending[convKey].isn = giipIsn; saveJSON(TASK_STATE_FILE, taskState); }
   } catch (e) { console.error('[Bot] giip issue 등록 훅 오류:', e.message); }
   const isnLine = giipIsn ? `\n🔗 giip issue #${giipIsn} (IN_PROGRESS)` : '';
@@ -943,7 +983,7 @@ async function processMessage({ channelId, msg, isDM, conversations, threadTs })
     .trim();
 
   // プロジェクトプレフィックス検出: "giipprj 何か" → giipprj フォルダに切り替え
-  const { workDir, cleanText } = parseProjectPrefix(rawCleanText);
+  const { workDir, cleanText, projectName } = parseProjectPrefix(rawCleanText);
 
   const hasFiles = msg.files && msg.files.length > 0;
   if (hasFiles && !cleanText) {
@@ -957,7 +997,7 @@ async function processMessage({ channelId, msg, isDM, conversations, threadTs })
   if (isDM) {
     await handleDM({ channelId, ts: msg.ts, threadTs: effectiveThreadTs, text: cleanText, conversations, workDir });
   } else if (mentionsBot || isTaskReply || isEngagedThread) {
-    await handleChannelMention({ channelId, ts: msg.ts, threadTs: effectiveThreadTs, text: cleanText, workDir });
+    await handleChannelMention({ channelId, ts: msg.ts, threadTs: effectiveThreadTs, text: cleanText, workDir, projectName });
   }
 }
 

--- a/slack-bot/project-csn.json
+++ b/slack-bot/project-csn.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Slack에서 처음 언급한 프로젝트명(소문자) → giip csn 매핑. '<프로젝트명> issue 등록 <내용>' 로 말하면 그 프로젝트의 csn 으로 giip issue 를 등록한다(예: 'caci-mimity issue 등록 ...' → csn 70422). 다수 프로젝트는 여기 map 에 항목만 추가하면 된다(코드 변경 불필요). 편집은 Slack 커맨드 `giip project set <프로젝트명> <csn>` / `giip project list` / `giip project del <프로젝트명>` 로도 가능(재시작 불필요). PROJECTS_ROOT 직하에 같은 이름 폴더가 있으면 그 폴더로 작업 전환도 되고, 폴더가 없어도 이 map 에 있으면 이름만으로 csn 라우팅된다(그 경우 workDir 은 BASE_DIR 로 안전 폴백). 여기에 없으면 account.csn(default)로 폴백. 비밀 아님 → git 추적.",
+  "map": {}
+}


### PR DESCRIPTION
## 목적
Lowyworkenv 라이브 봇에 도입한 **복수 CSN 관리 기능**(PR #351/#352)을 이 템플릿에도 이식.
`<프로젝트명> issue 등록 <내용>` 을 프로젝트별 **CSN** 으로 giip issue 등록하고, 매핑은 Slack 커맨드로 관리한다(코드 변경·봇 재시작 불필요).

## 커맨드
| 커맨드 | 동작 |
|---|---|
| `giip project set <프로젝트명> <csn>` | 매핑 추가/갱신(소문자 정규화, 정수 검증) |
| `giip project list` | 매핑 일람 |
| `giip project del <프로젝트명>` | 매핑 삭제 |

별칭 `giip proj` / `giip csn`. `<프로젝트> issue 등록 <내용>` → 매핑된 csn 으로 PENDING 등록(미등록 시 account 기본 csn).

## 변경
- **project-csn.json**(신규): 템플릿 기본 = 빈 map + 안내 `_comment`.
- **config.js**: `resolveProjectCsn/setProjectCsn/listProjectCsn/deleteProjectCsn` 추가. `parseProjectPrefix` 가 `projectName` 반환 + 폴더없는 프로젝트명도 map 에 있으면 라우팅(`workDir` 은 `BASE_DIR` 안전 폴백). **템플릿 고유의 env 기반 `BASE_DIR`/`PROJECTS_ROOT` 설정은 그대로 보존.**
- **giip-commands.js**: `giip project` 서브커맨드(account 게이트보다 앞서 처리).
- **giip-task.js**: `maybeCreateIssue` 에 `csn` 인자 추가(null 이면 `account.csn` 폴백).
- **handlers.js**: `<프로젝트> issue 등록` 핸들러 추가 + `projectName` 스레딩 + 태스크 자동 issue csn 라우팅.
- **README**: Per-project giip CSN routing 섹션.

## 검증
`node --check` 6파일 통과 · 전체 모듈 로드 OK · 핸들러 단위 테스트(set/list/del/정수검증/소문자화/parseProjectPrefix 라우팅/`_comment` 보존) 정상.

## 참고
- 베이스는 `main`(모듈러 아키텍처, 라이브 봇과 동형). 이미 giip 서브시스템(giip-api/accounts/commands/handlers)이 있어 이번엔 **CSN 관리 델타만** 얹음.
- 운영 반영 시 봇 재시작 필요(pm2 운용 시).

🤖 Generated with [Claude Code](https://claude.com/claude-code)